### PR TITLE
Revert "Use shallow git clones"

### DIFF
--- a/.taskclusterrc
+++ b/.taskclusterrc
@@ -6,7 +6,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone --depth=50 ${GITHUB_HEAD_REPO_URL} releasetasks && cd releasetasks && git checkout ${GITHUB_HEAD_SHA} && tox -e py27"
+        - "git clone ${GITHUB_HEAD_REPO_URL} && cd releasetasks && git checkout ${GITHUB_HEAD_SHA} && tox -e py27"
     extra:
       github_events:
         - pull_request.*


### PR DESCRIPTION
Reverts mozilla/releasetasks#27, it breaks PRs
