### PR TITLE
Move back to l10n chunks, and set locales property

### DIFF
--- a/releasetasks/__init__.py
+++ b/releasetasks/__init__.py
@@ -4,6 +4,7 @@ from os import path
 import yaml
 
 import arrow
+from chunkify import chunkify
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from taskcluster.utils import stableSlugId
@@ -22,6 +23,7 @@ def make_task_graph(root_template="release_graph.yml.tmpl", template_dir=DEFAULT
     template = env.get_template(root_template)
     template_vars = {
         "stableSlugId": stableSlugId(),
+        "chunkify": chunkify,
         "now": now,
         "now_ms": now_ms,
         # This is used in defining expirations in tasks. There's no way to

--- a/releasetasks/__init__.py
+++ b/releasetasks/__init__.py
@@ -24,6 +24,7 @@ def make_task_graph(root_template="release_graph.yml.tmpl", template_dir=DEFAULT
     template_vars = {
         "stableSlugId": stableSlugId(),
         "chunkify": chunkify,
+        "sorted": sorted,
         "now": now,
         "now_ms": now_ms,
         # This is used in defining expirations in tasks. There's no way to

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -1,6 +1,6 @@
 {% for platform in l10n_platforms %}
 {% for chunk in range(1, l10n_chunks+1) %}
-{% set our_locales = chunkify(l10n_changesets, chunk, l10n_chunks) %}
+{% set our_locales = chunkify(sorted(l10n_changesets), chunk, l10n_chunks) %}
 # TODO: make a helper function to generate consistent builder names?
 {% set buildername = "{}_{}_{}_l10n_repack".format(branch, product, platform) %}
 -

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -28,7 +28,7 @@
                 # Or maybe a manifest to look it up in
                 # Also this should probably be calculate in release runner, verified (for non-404), and passed in
                 {# en_us_binary_url: https://queue.taskcluster.net/v1/task/\{\{ en_task_id \}\}/artifacts/public/build/\{\{ product \}\}-\{\{ version \}\}.en-US.\{\{ ftp_platform \}\}.extension #}
-                locales: {% for l in our_locales %}{{ '{}:{} '.format(l, l10n_changesets[l]) }}{% endfor %}
+                locales: "{% for l in our_locales %}{{ '{}:{} '.format(l, l10n_changesets[l]) }}{% endfor %}"
 
         metadata:
             name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ l10n_chunks }}"

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -28,7 +28,9 @@
                 # Or maybe a manifest to look it up in
                 # Also this should probably be calculate in release runner, verified (for non-404), and passed in
                 {# en_us_binary_url: https://queue.taskcluster.net/v1/task/\{\{ en_task_id \}\}/artifacts/public/build/\{\{ product \}\}-\{\{ version \}\}.en-US.\{\{ ftp_platform \}\}.extension #}
-                locales: "{% for l in our_locales %}{{ '{}:{} '.format(l, l10n_changesets[l]) }}{% endfor %}"
+                # Quotes cannot be used around this string because the loop causes it to have trailing whitespace
+                # (which gets stripped by the yaml parser when unquoted). Kindof hacky.
+                locales: {% for l in our_locales %}{{ '{}:{} '.format(l, l10n_changesets[l]) }}{% endfor %}
 
         metadata:
             name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ l10n_chunks }}"

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -1,10 +1,13 @@
 {% for platform in l10n_platforms %}
-# TODO: iterate over platform specific locales...probably need l10n json to do this
-{% for locale, locale_revision in l10n_changesets.iteritems() %}
+{% for chunk in range(1, l10n_chunks+1) %}
+{% set our_locales = chunkify(l10n_changesets, chunk, l10n_chunks) %}
 # TODO: make a helper function to generate consistent builder names?
 {% set buildername = "{}_{}_{}_l10n_repack".format(branch, product, platform) %}
 -
-    taskId: "{{ stableSlugId(buildername) }}"
+    # We have multiple chunks of l10n per platform, so we need unique task ids
+    # for each of them. However, they all share the same builder because the
+    # only differences between them are in the properties that we set.
+    taskId: "{{ stableSlugId('{}_{}'.format(buildername, chunk)) }}"
     reruns: 5
     task:
         provisionerId: "buildbot-bridge"
@@ -21,10 +24,19 @@
                 branch: "{{ repo_path }}"
                 revision: "{{ revision }}"
             properties:
-                extra_args: "--locale {{ '{}:{} '.format(locale, locale_revision)}}"
+                # TODO: It would be better to have a stable artifact name like public/build/installer
+                # Or maybe a manifest to look it up in
+                # Also this should probably be calculate in release runner, verified (for non-404), and passed in
+                {# en_us_binary_url: https://queue.taskcluster.net/v1/task/\{\{ en_task_id \}\}/artifacts/public/build/\{\{ product \}\}-\{\{ version \}\}.en-US.\{\{ ftp_platform \}\}.extension #}
+                locales: {% for l in our_locales %}{{ '{}:{} '.format(l, l10n_changesets[l]) }}{% endfor %}
 
         metadata:
-            name: "{{ product }} {{ branch }} {{ platform }} {{ locale }} l10n repack"
+            name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ l10n_chunks }}"
+
+        {% if running_tests is defined %}
+        extra:
+            task_name: "{{ buildername }}_{{ chunk }}"
+        {% endif %}
 
 {% endfor %}
 {% endfor %}

--- a/releasetasks/templates/release_graph.yml.tmpl
+++ b/releasetasks/templates/release_graph.yml.tmpl
@@ -40,9 +40,10 @@ tasks:
     {{ source_tasks()|indent(4) }}
     {% endif %}
 
-# {# Commented out until buildbot builders exist
-#    {% macro l10n_tasks() %}{% include "l10n.yml.tmpl" %}{% endmacro %}
-#    {{ l10n_tasks()|indent(4) }} #}
+    {% if l10n_platforms %}
+    {% macro l10n_tasks() %}{% include "l10n.yml.tmpl" %}{% endmacro %}
+    {{ l10n_tasks()|indent(4) }}
+    {% endif %}
 
     {% if updates_enabled %}
     {% for platform in enUS_platforms %}

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -244,7 +244,8 @@ class TestMakeTaskGraph(unittest.TestCase):
         self.assertEqual(properties["locales"], "de:default en-GB:default zh-TW:default")
 
         # Make sure only one chunk was generated
-        self.assertEqual(get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_2"), None)
+        self.assertIsNone(get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_0"))
+        self.assertIsNone(get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_2"))
 
     def test_l10n_multiple_chunks(self):
         graph = make_task_graph(

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -33,7 +33,7 @@ class TestMakeTaskGraph(unittest.TestCase):
         if graph["tasks"]:
             for t in graph["tasks"]:
                 task = t["task"]
-                self.assertEquals(task["priority"], "high")
+                self.assertEqual(task["priority"], "high")
                 self.assertIn("task_name", task["extra"])
 
     def test_source_task_definition(self):
@@ -50,8 +50,8 @@ class TestMakeTaskGraph(unittest.TestCase):
 
         task = get_task_by_name(graph, "foo_source")["task"]
         payload = task["payload"]
-        self.assertEquals(task["provisionerId"], "aws-provisioner-v1")
-        self.assertEquals(task["workerType"], "opt-linux64")
+        self.assertEqual(task["provisionerId"], "aws-provisioner-v1")
+        self.assertEqual(task["workerType"], "opt-linux64")
         self.assertTrue(payload["image"].startswith("taskcluster/desktop-build:"))
         self.assertTrue("cache" in payload)
         self.assertTrue("artifacts" in payload)
@@ -89,7 +89,7 @@ class TestMakeTaskGraph(unittest.TestCase):
         )
 
         self._do_common_assertions(graph)
-        self.assertEquals(graph["tasks"], None)
+        self.assertEqual(graph["tasks"], None)
 
         expected_scopes = set([
             "signing:format:gpg",
@@ -130,8 +130,8 @@ class TestMakeTaskGraph(unittest.TestCase):
                 balrog = get_task_by_name(graph, "{}_en-US_{}_funsize_balrog_task".format(p, v))
 
                 self.assertIsNone(generator.get("requires"))
-                self.assertEquals(signing.get("requires"), [generator["taskId"]])
-                self.assertEquals(balrog.get("requires"), [signing["taskId"]])
+                self.assertEqual(signing.get("requires"), [generator["taskId"]])
+                self.assertEqual(balrog.get("requires"), [signing["taskId"]])
 
     def test_funsize_en_US_scopes(self):
         graph = make_task_graph(
@@ -213,7 +213,7 @@ class TestMakeTaskGraph(unittest.TestCase):
                 self.assertItemsEqual(signing["task"]["scopes"], ["signing:cert:dep-signing", "signing:format:mar", "signing:format:gpg"])
                 self.assertIsNone(balrog["task"].get("scopes"))
 
-    def test_l10n_simple(self):
+    def test_l10n_one_chunk(self):
         graph = make_task_graph(
             source_enabled=False,
             updates_enabled=False,
@@ -233,12 +233,15 @@ class TestMakeTaskGraph(unittest.TestCase):
 
         self._do_common_assertions(graph)
 
-        task = get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_1/1")
+        task = get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_1")
 
         payload = task["task"]["payload"]
         properties = payload["properties"]
+        # The order of the locales is not predictable, so we need to sort them
+        # before comparing against our reference value.
+        locales = sorted(properties["locales"].split())
 
-        self.assertEquals(task["task"]["provisionerId"], "buildbot-bridge")
-        self.assertEquals(task["task"]["workerType"], "buildbot-bridge")
-        self.assertEquals(payload["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
-        self.assertEquals(properties["locales"], "de:default en-GB:default zh-TW:default")
+        self.assertEqual(task["task"]["provisionerId"], "buildbot-bridge")
+        self.assertEqual(task["task"]["workerType"], "buildbot-bridge")
+        self.assertEqual(payload["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
+        self.assertEqual(locales, ["de:default", "en-GB:default", "zh-TW:default"])

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -243,6 +243,9 @@ class TestMakeTaskGraph(unittest.TestCase):
         self.assertEqual(payload["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
         self.assertEqual(properties["locales"], "de:default en-GB:default zh-TW:default")
 
+        # Make sure only one chunk was generated
+        self.assertEqual(get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_2"), None)
+
     def test_l10n_multiple_chunks(self):
         graph = make_task_graph(
             source_enabled=False,
@@ -271,7 +274,9 @@ class TestMakeTaskGraph(unittest.TestCase):
         chunk1_locales = chunk1["task"]["payload"]["properties"]["locales"]
         chunk2_locales = chunk2["task"]["payload"]["properties"]["locales"]
 
-        self.assertEquals(chunk1["task"]["payload"]["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
-        self.assertEquals(chunk1_locales, "de:default en-GB:default ru:default")
-        self.assertEquals(chunk2["task"]["payload"]["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
-        self.assertEquals(chunk2_locales, "uk:default zh-TW:default")
+        self.assertEqual(chunk1["task"]["payload"]["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
+        self.assertEqual(chunk1_locales, "de:default en-GB:default ru:default")
+        self.assertEqual(chunk2["task"]["payload"]["buildername"], "mozilla-beta_firefox_win32_l10n_repack")
+        self.assertEqual(chunk2_locales, "uk:default zh-TW:default")
+
+        self.assertEqual(get_task_by_name(graph, "mozilla-beta_firefox_win32_l10n_repack_3"), None)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     "arrow",
     "requests>=2.4.3,<=2.7.0",
     "PyYAML",
+    "chunkify",
 ]
 test_requirements = [
     "pytest",


### PR DESCRIPTION
Flagging @rail and @nthomas-mozilla for review.

This won't make l10n actually work, but it will get us chunking again, and set the required "locales" property. Jobs will still fail because en_us_binary_url is unset, but I think I'll tackle that in a subsequent patch - this one is big enough already.

I'm not super happy with this...but it works. We seem to be getting close to the "too much code in templates" state, as evidenced by my needing to pass in chunkify and sorted to the template. I wonder if we should get rid of the top level task graph, and do the including of l10n and other tasks in Python code? That would let us do chunk iteration in Python code, and maybe get rid of the hacky include/indent stuff. I'm curious what you both think about that.

Another interesting thing about this patch is that it's our first example of builder name not matching what the slug is based on, since we need multiple task ids that all use the same builder. That's not a big deal, really, but perhaps noteworthy.
