### PR TITLE
Revert "Update ci image"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -9,11 +9,11 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     payload:
       maxRunTime: 1200
-      image: "quay.io/mrrrgn/ubuntu-ci:0.0.2"
+      image: "rail/python-test-runner"
       command:
         - "/bin/bash"
         - "-c"
-        - "checkout-pull-request && pip install tox==2.1.1 && cd repo && tox -e py27"
+        - "git clone $GITHUB_HEAD_REPO_URL && cd releasetasks && git checkout $GITHUB_HEAD_BRANCH && tox -e py27"
     extra:
       github:
         env: true


### PR DESCRIPTION
Reverts mozilla/releasetasks#34 due to underlying issues with the image.
