### PR TITLE
Fix issues causing graph validation errors

### DIFF
--- a/releasetasks/templates/funsize.yml.tmpl
+++ b/releasetasks/templates/funsize.yml.tmpl
@@ -62,22 +62,22 @@
 
         payload:
             image: "rail/funsize-update-generator:latest"
-        maxRunTime: 900
-        command:
-            - /runme.sh
+            maxRunTime: 900
+            command:
+                - /runme.sh
 
-        env:
-            FROM_MAR: "{{ get_complete_mar_url(product, platform, locale, partial_version) }}"
-            TO_MAR: "{{ get_complete_mar_artifact(platform, branch, revision) }}"
-            PLATFORM: "{{ platform }}"
-            LOCALE: "{{ locale }}"
-            SIGNING_CERT: "release"
+            env:
+                FROM_MAR: "{{ get_complete_mar_url(product, platform, locale, partial_version) }}"
+                TO_MAR: "{{ get_complete_mar_artifact(platform, branch, revision) }}"
+                PLATFORM: "{{ platform }}"
+                LOCALE: "{{ locale }}"
+                SIGNING_CERT: "release"
 
-        artifacts:
-            "public/env":
-                path: /home/worker/artifacts/
-                type: directory
-                expires: "{{ never }}"
+            artifacts:
+                "public/env":
+                    path: /home/worker/artifacts/
+                    type: directory
+                    expires: "{{ never }}"
 
 -
     taskId: "{{ stableSlugId('{}_signing_task'.format(basename)) }}"
@@ -176,26 +176,26 @@
 
         payload:
             image: "rail/funsize-balrog-submitter:latest"
-        maxRunTime: 1800
-        command:
-            - /runme.sh
+            maxRunTime: 1800
+            command:
+                - /runme.sh
 
-        env:
-            PARENT_TASK_ARTIFACTS_URL_PREFIX: "https://queue.taskcluster.net/v1/task/{{ stableSlugId('{}_signing_task'.format(basename)) }}/artifacts/public/env"
-            BALROG_API_ROOT: {{ balrog_api_root }}
-            # TODO: should funsize be publishing to an s3 bucket? or will beetmover do that?
-            SIGNING_CERT: "release"
-            {% if extra_balrog_submitter_params is defined %}
-            EXTRA_BALROG_SUBMITTER_PARAMS: "{{ extra_balrog_submitter_params }}"
-            {% endif %}
-        encryptedEnv:
-            - {{ encrypt_env_var(stableSlugId('{}_balrog_task'.format(basename)), now_ms,
-                                now_ms + 24 * 3600 * 1000, "BALROG_USERNAME",
-                                balrog_username) }}
-            - {{ encrypt_env_var(stableSlugId('{}_balrog_task'.format(basename)), now_ms,
-                                now_ms + 24 * 3600 * 1000, "BALROG_PASSWORD",
-                                balrog_password) }}
-        features:
-            balrogVPNProxy: true
+            env:
+                PARENT_TASK_ARTIFACTS_URL_PREFIX: "https://queue.taskcluster.net/v1/task/{{ stableSlugId('{}_signing_task'.format(basename)) }}/artifacts/public/env"
+                BALROG_API_ROOT: {{ balrog_api_root }}
+                # TODO: should funsize be publishing to an s3 bucket? or will beetmover do that?
+                SIGNING_CERT: "release"
+                {% if extra_balrog_submitter_params is defined %}
+                EXTRA_BALROG_SUBMITTER_PARAMS: "{{ extra_balrog_submitter_params }}"
+                {% endif %}
+            encryptedEnv:
+                - {{ encrypt_env_var(stableSlugId('{}_balrog_task'.format(basename)), now_ms,
+                                    now_ms + 24 * 3600 * 1000, "BALROG_USERNAME",
+                                    balrog_username) }}
+                - {{ encrypt_env_var(stableSlugId('{}_balrog_task'.format(basename)), now_ms,
+                                    now_ms + 24 * 3600 * 1000, "BALROG_PASSWORD",
+                                    balrog_password) }}
+            features:
+                balrogVPNProxy: true
 
 {% endfor %}

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -20,7 +20,7 @@
 
         payload:
             buildername: "{{ buildername }}"
-            product; "{{ product }}"
+            product: "{{ product }}"
             sourcestamp:
                 branch: "{{ repo_path }}"
                 revision: "{{ revision }}"

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -14,12 +14,13 @@
         workerType: "buildbot-bridge"
         created: "{{ now }}"
         deadline: "{{ now.replace(hours=36) }}"
-        expires: {{ never }}"
+        expires: "{{ never }}"
         priority: "high"
         retries: 5
 
         payload:
             buildername: "{{ buildername }}"
+            product; "{{ product }}"
             sourcestamp:
                 branch: "{{ repo_path }}"
                 revision: "{{ revision }}"
@@ -31,6 +32,9 @@
 
         metadata:
             name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ platform_info["chunks"] }}"
+            description: "Release Promotion l10n repack job"
+            owner: "release@mozilla.com"
+            source: https://github.com/mozilla/releasetasks
 
         {% if running_tests is defined %}
         extra:


### PR DESCRIPTION
We found some issues with the Funsize graphs because of indentation issues, those were simple to fix. There was also a few issues with the l10n ones:
- Missing " in expires
- Missing "product" in properties, which is now required for buildbot bridge jobs
- Missing metadata
