### PR TITLE
Bug 1211686 - release promotion l10n logs should upload to proper location

### DIFF
--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -33,6 +33,7 @@
                 locales: {% for l in our_locales %}{{ "{}:{} ".format(l, l10n_config["changesets"][l]) }}{% endfor %}
                 version: {{ version }}
                 build_number: {{ buildNumber }}
+                release_promotion: true
 
         metadata:
             name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ platform_info["chunks"] }}"

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -31,6 +31,8 @@
                 # Quotes cannot be used around this string because the loop causes it to have trailing whitespace
                 # (which gets stripped by the yaml parser when unquoted). Kindof hacky.
                 locales: {% for l in our_locales %}{{ "{}:{} ".format(l, l10n_config["changesets"][l]) }}{% endfor %}
+                version: {{ version }}
+                build_number: {{ buildNumber }}
 
         metadata:
             name: "{{ product }} {{ branch }} {{ platform }} l10n repack {{ chunk }}/{{ platform_info["chunks"] }}"

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -45,6 +45,11 @@ class TestMakeTaskGraph(unittest.TestCase):
                 task = t["task"]
                 self.assertEqual(task["priority"], "high")
                 self.assertIn("task_name", task["extra"])
+                properties = task["payload"].get("properties")
+                if properties:
+                    # The following properties are required by log_uploader.py
+                    self.assertIn("version", properties)
+                    self.assertIn("build_number", properties)
 
     def test_source_task_definition(self):
         graph = make_task_graph(

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -50,6 +50,7 @@ class TestMakeTaskGraph(unittest.TestCase):
                     # The following properties are required by log_uploader.py
                     self.assertIn("version", properties)
                     self.assertIn("build_number", properties)
+                    self.assertIn("release_promotion", properties)
 
     def test_source_task_definition(self):
         graph = make_task_graph(


### PR DESCRIPTION
Add `version` and `build_number` properties required by log_uploader.py passed from http://hg.mozilla.org/build/buildbotcustom/file/eec34447bf3d/bin/postrun.py#l71
