### PR TITLE
Fix typo in final_verify task

### DIFF
--- a/releasetasks/templates/final_verify.yml.tmpl
+++ b/releasetasks/templates/final_verify.yml.tmpl
@@ -16,7 +16,7 @@
             command:
                 - /bin/bash
                 - -c
-                - hg clone https://hg.mozilla.org/build/tools && cd tools && hg up -r $TAG && cd release/ && ./final-verification.sh $RELEASE_CONFIGS"
+                - hg clone https://hg.mozilla.org/build/tools && cd tools && hg up -r $TAG && cd release/ && ./final-verification.sh $RELEASE_CONFIGS
             env:
                 TAG: "default"
                 RELEASE_CONFIGS: {% for key, val in verifyConfigs.iteritems() %}{{ val }} {% endfor %}


### PR DESCRIPTION
This fixes up final_verify (still runs at the outset of the release job)
