### PR TITLE
Prettify the jinja a bit

### DIFF
--- a/releasetasks/templates/release_graph.yml.tmpl
+++ b/releasetasks/templates/release_graph.yml.tmpl
@@ -41,24 +41,32 @@ scopes:
 
 tasks:
     {% if source_enabled %}
-    {% macro source_tasks() %}{% include "source.yml.tmpl" %}{% endmacro %}
-    {{ source_tasks()|indent(4) }}
+        {% macro source_tasks() %}
+            {% include "source.yml.tmpl" %}
+        {% endmacro %}
+        {{ source_tasks()|indent(4) }}
     {% endif %}
 
     {% if l10n_config.get("platforms") %}
-    {% macro l10n_tasks() %}{% include "l10n.yml.tmpl" %}{% endmacro %}
-    {{ l10n_tasks()|indent(4) }}
+        {% macro l10n_tasks() %}
+            {% include "l10n.yml.tmpl" %}
+        {% endmacro %}
+        {{ l10n_tasks()|indent(4) }}
     {% endif %}
 
     {% if updates_enabled %}
-    {% for platform in enUS_platforms %}
-    {% set locale = "en-US" %}
-    {% macro funsize_tasks() %}{% include "funsize.yml.tmpl" %}{% endmacro %}
-    {{ funsize_tasks()|indent(4) }}
-    {% endfor %}
+        {% for platform in enUS_platforms %}
+            {% set locale = "en-US" %}
+            {% macro funsize_tasks() %}
+                {% include "funsize.yml.tmpl" %}
+            {% endmacro %}
+            {{ funsize_tasks()|indent(4) }}
+        {% endfor %}
     {% endif %}
 
     {% if verifyConfigs %}
-    {% macro finalVerify_tasks() %}{% include "final_verify.yml.tmpl" %}{% endmacro %}
-    {{ finalVerify_tasks()|indent(4) }}
+        {% macro finalVerify_tasks() %}
+            {% include "final_verify.yml.tmpl" %}
+        {% endmacro %}
+        {{ finalVerify_tasks()|indent(4) }}
     {% endif %}


### PR DESCRIPTION
In a manual comparison with printing out the pretified content after a yaml load, the added indents here make no difference.
