### PR TITLE
Bug 1230562 - Add basic support for multiple release channels, and use channel instead of branch for verification config files. r=jlund

### DIFF
--- a/releasetasks/templates/final_verify.yml.tmpl
+++ b/releasetasks/templates/final_verify.yml.tmpl
@@ -1,4 +1,5 @@
-{% set buildername = "{}_final_verify".format(branch) %}
+{% for channel in release_channels %}
+{% set buildername = "{}_final_verify".format(channel) %}
 -
     taskId: "{{ stableSlugId(buildername) }}"
     reruns: 5
@@ -19,7 +20,13 @@
                 - hg clone https://hg.mozilla.org/build/tools && cd tools && hg up -r $TAG && cd release/ && ./final-verification.sh $RELEASE_CONFIGS
             env:
                 TAG: "default"
-                RELEASE_CONFIGS: {% for key, val in verifyConfigs.iteritems() %}{{ val }} {% endfor %}
+                RELEASE_CONFIGS: {#
+                    #}{% for platform in enUS_platforms %}{#
+                        #}{{ "{channel}-{product}-{platform}.cfg".format(
+                               platform=platform,
+                               channel=channel,
+                               product=product) }} {#
+                    #}{% endfor %}
         metadata:
             owner: release@mozilla.com
             source: https://github.com/mozilla/releasetasks
@@ -43,3 +50,4 @@
             build:
                 platform: none
         #}
+{% endfor %}

--- a/releasetasks/templates/release_graph.yml.tmpl
+++ b/releasetasks/templates/release_graph.yml.tmpl
@@ -71,7 +71,7 @@ tasks:
         {{ bouncer_tasks()|indent(4) }}
     {% endif %}
 
-    {% if verifyConfigs %}
+    {% if release_channels is defined %}
         {% macro updateVerify_task(platform) %}
             {% if platform in ["linux", "linux64"] %}
                 {% include "tc_update_verify.yml.tmpl" %}
@@ -81,7 +81,7 @@ tasks:
             # End comment #}
             {% endif %}
         {% endmacro %}
-        {% for plat in verifyConfigs.keys() %}
+        {% for plat in enUS_platforms %}
             {{ updateVerify_task(plat)|indent(4) }}
         {% endfor %}
 

--- a/releasetasks/templates/tc_update_verify.yml.tmpl
+++ b/releasetasks/templates/tc_update_verify.yml.tmpl
@@ -1,6 +1,7 @@
+{% for channel in release_channels %}
 {% set uv_totalchunks = 12 %}
 {% for chunk in range(uv_totalchunks) %}
-{% set uv_buildername = "{}_{}_update_verify_{}".format(platform, branch, chunk) %}
+{% set uv_buildername = "{}_{}_update_verify_{}".format(platform, channel, chunk) %}
 -
     taskId: "{{ stableSlugId(uv_buildername) }}"
     reruns: 5
@@ -24,11 +25,14 @@
                 TOTAL_CHUNKS: "{{ uv_totalchunks }}"
                 THIS_CHUNK: "{{ chunk + 1 }}"
                 NO_BBCONFIG: "1"
-                VERIFY_CONFIG: "{{ verifyConfigs[platform] }}"
+                VERIFY_CONFIG: "{{ "{channel}-{product}-{platform}.cfg".format(
+                                   platform=platform,
+                                   channel=channel,
+                                   product=product) }}"
         metadata:
             owner: release@mozilla.com
             source: https://github.com/mozilla/releasetasks
-            name: "{{ platform }} {{ branch }} update verification"
+            name: "{{ platform }} {{ channel }} update verification"
             description: |
                 Verifies updates for {{ platform }}
 
@@ -48,4 +52,5 @@
             build:
                 platform: none
         #}
+{% endfor %}
 {% endfor %}

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -298,11 +298,7 @@ class TestMakeTaskGraph(unittest.TestCase):
             revision="abcdef123456",
             balrog_api_root="https://fake.balrog/api",
             signing_class="dep-signing",
-            verifyConfigs={'linux': "beta-firefox-linux.cfg",
-                           'linux64': "beta-firefox-linux64.cfg",
-                           'macosx64': "beta-firefox-macosx64.cfg",
-                           'win32': "beta-firefox-win32.cfg",
-                           'win64': "beta-firefox-win64.cfg"}
+            release_channels=["beta"],
         )
 
         self._do_common_assertions(graph)
@@ -357,11 +353,7 @@ class TestMakeTaskGraph(unittest.TestCase):
             product="firefox",
             repo_path="releases/mozilla-beta",
             revision="abcdef123456",
-            verifyConfigs={'linux': "beta-firefox-linux.cfg",
-                           'linux64': "beta-firefox-linux64.cfg",
-                           'macosx64': "beta-firefox-macosx64.cfg",
-                           'win32': "beta-firefox-win32.cfg",
-                           'win64': "beta-firefox-win64.cfg"}
+            release_channels=["beta"],
         )
 
         self._do_common_assertions(graph)
@@ -413,11 +405,7 @@ class TestMakeTaskGraph(unittest.TestCase):
             product="firefox",
             repo_path="releases/mozilla-beta",
             revision="abcdef123456",
-            verifyConfigs={'linux': "beta-firefox-linux.cfg",
-                           'linux64': "beta-firefox-linux64.cfg",
-                           'macosx64': "beta-firefox-macosx64.cfg",
-                           'win32': "beta-firefox-win32.cfg",
-                           'win64': "beta-firefox-win64.cfg"}
+            release_channels=["beta"],
         )
 
         self._do_common_assertions(graph)
@@ -464,11 +452,7 @@ class TestMakeTaskGraph(unittest.TestCase):
             revision="abcdef123456",
             balrog_api_root="https://fake.balrog/api",
             signing_class="dep-signing",
-            verifyConfigs={'linux': "beta-firefox-linux.cfg",
-                           'linux64': "beta-firefox-linux64.cfg",
-                           'macosx64': "beta-firefox-macosx64.cfg",
-                           'win32': "beta-firefox-win32.cfg",
-                           'win64': "beta-firefox-win64.cfg"}
+            release_channels=["beta"],
         )
         self._do_common_assertions(graph)
         for p in ("win32", "macosx64"):
@@ -495,12 +479,10 @@ class TestMakeTaskGraph(unittest.TestCase):
             branch="foo",
             updates_enabled=False,
             bouncer_enabled=False,
+            product="firefox",
             signing_class="release-signing",
-            verifyConfigs={'linux': "foo-firefox-linux.cfg",
-                           'linux64': "foo-firefox-linux64.cfg",
-                           'macosx64': "foo-firefox-macosx64.cfg",
-                           'win32': "foo-firefox-win32.cfg",
-                           'win64': "foo-firefox-win64.cfg"}
+            release_channels=["foo"],
+            enUS_platforms=["linux", "linux64", "win64", "win32", "macosx64"],
         )
         self._do_common_assertions(graph)
 
@@ -544,7 +526,8 @@ class TestMakeTaskGraph(unittest.TestCase):
             updates_enabled=False,
             bouncer_enabled=True,
             signing_class="release-signing",
-            verifyConfigs={}
+            release_channels=["foo"],
+            enUS_platforms=["linux", "linux64", "win64", "win32", "macosx64"],
         )
         self._do_common_assertions(graph)
 
@@ -564,3 +547,46 @@ class TestMakeTaskGraph(unittest.TestCase):
             "queue:task-priority:high",
         ])
         self.assertTrue(expected_graph_scopes.issubset(graph["scopes"]))
+
+    def test_multi_channel_final_verify_task_definition(self):
+        graph = make_task_graph(
+            version="42.0b2",
+            appVersion="42.0",
+            buildNumber=3,
+            source_enabled=False,
+            en_US_config={"platforms": {
+                "linux": {"task_id": "xyz"},
+                "win32": {"task_id": "xyy"}
+            }},
+            l10n_config={},
+            repo_path="releases/foo",
+            revision="fedcba654321",
+            branch="foo",
+            updates_enabled=False,
+            bouncer_enabled=False,
+            product="firefox",
+            signing_class="release-signing",
+            release_channels=["beta", "release"],
+            enUS_platforms=["linux", "linux64", "win64", "win32", "macosx64"],
+        )
+        self._do_common_assertions(graph)
+
+        for chan in ["beta", "release"]:
+            task_def = get_task_by_name(graph,
+                                        "{chan}_final_verify".format(chan=chan))
+            task = task_def["task"]
+            payload = task["payload"]
+            self.assertEqual(task["provisionerId"], "aws-provisioner-v1")
+            self.assertEqual(task["workerType"], "b2gtest")
+            self.assertFalse("scopes" in task)
+            # XXX: Change the image name once it's in-tree.
+            self.assertTrue(payload["image"].startswith("rail/python-test-runner"))
+            self.assertFalse("cache" in payload)
+            self.assertFalse("artifacts" in payload)
+            self.assertTrue("env" in payload)
+            self.assertTrue("command" in payload)
+
+            expected_graph_scopes = set([
+                "queue:task-priority:high",
+            ])
+            self.assertTrue(expected_graph_scopes.issubset(graph["scopes"]))


### PR DESCRIPTION
This does not yet care about the fact that a release like 34.0.5 could be built after a release like 35.0b4 in terms of human time. (but for this piece, that distinction doesn't really matter much anyway)
