### PR TITLE
Bug 1208182 - unstub funsize mar urls in release promotion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,9 @@ Features
 --------
 
 * TODO
+
+Testing
+-------
+
+Example test invocation using docker:
+  docker run --rm -v `pwd`:/src -ti rail/python-test-runner /bin/sh -c "cd /src && tox"

--- a/releasetasks/templates/funsize.yml.tmpl
+++ b/releasetasks/templates/funsize.yml.tmpl
@@ -37,11 +37,7 @@
                         # TODO: consider using stable URL for from_mar
                         from_mar: "http://download.mozilla.org/?product={{ product }}-{{ partial_version }}-complete&os={{ buildbot2bouncer(platform) }}&lang={{ locale }}"
                         # en-US: task ID comes from from buildbot via releaserunner
-                        {% if locale == "en-US" %}
                         to_mar: "https://queue.taskcluster.net/v1/task/{{ en_US_config["platforms"][platform]["task_id"] }}/artifacts/public/build/{{ product }}-{{ appVersion }}.{{ locale }}.{{ buildbot2ftp(platform) }}.complete.mar"
-                        {% else %}
-                        to_mar: "TODO: generate mar url using BBB task_id and locale"
-                        {% endif %}
                         platform: {{ platform }}
                         branch: {{ branch }}
                         previousVersion: {{ partial_version }}
@@ -51,7 +47,7 @@
             treeherderEnv:
                 - staging
             treeherder:
-                symbol: {{ locale }}-{{ partial_version }}-1
+                symbol: {{ locale }}-{{ partial_version }}-g
                 groupSymbol: Update
                 collection:
                     opt: true
@@ -118,7 +114,7 @@
             treeherderEnv:
                 - staging
             treeherder:
-                symbol: {{ locale }}-{{ partial_version }}-2
+                symbol: {{ locale }}-{{ partial_version }}-s
                 groupSymbol: Update
                 collection:
                     opt: true
@@ -160,7 +156,7 @@
             treeherderEnv:
                 - staging
             treeherder:
-                symbol: {{ locale }}-{{ partial_version }}-3
+                symbol: {{ locale }}-{{ partial_version }}-u
                 groupSymbol: Update
                 collection:
                     opt: true

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -1,5 +1,5 @@
 {% for platform, platform_info in l10n_config["platforms"].iteritems() %}
-{% for chunk in range(1, platform_info["chunks"]+1) %}
+{% for chunk in range(1, platform_info["chunks"] + 1) %}
 {% set our_locales = chunkify(sorted(platform_info["locales"]), chunk, platform_info["chunks"]) %}
 # TODO: make a helper function to generate consistent builder names?
 {% set buildername = "release-{}_{}_{}_l10n_repack".format(branch, product, platform) %}
@@ -73,8 +73,209 @@
         extra:
             task_name: "{{ buildername }}_artifacts_{{ chunk }}"
         {% endif %}
-
+{% for partial_version, partial_info in partial_updates.iteritems() %}
+-
+    taskId: "{{ stableSlugId('{}_{}_{}_update_generator'.format(buildername, chunk, partial_version)) }}"
+    requires:
+        - "{{ stableSlugId('{}_artifacts_{}'.format(buildername, chunk)) }}"
+    task:
+        created: "{{ now }}"
+        deadline: "{{ now.replace(hours=24) }}"
+        expires: "{{ never }}"
+        priority: "high"
+        metadata:
+            owner: release+funsize@mozilla.com
+            source: https://github.com/mozilla/funsize
+            name: "[funsize] Update generating task"
+            description: |
+                This task generates MAR files and publishes unsigned bits.
+        routes:
+            - tc-treeherder-stage.{{ branch }}.{{ revision_hash }}
+            # TODO: add index routes
+        extra:
+            {% if running_tests is defined %}
+            task_name: "{{ '{}_{}_{}_update_generator'.format(buildername, chunk, partial_version) }}"
+            {% endif %}
+            funsize:
+                partials:
+{% for locale in our_locales %}
+                    -
+                        locale: {{ locale }}
+                        # TODO: consider using stable URL for from_mar
+                        from_mar: "http://download.mozilla.org/?product={{ product }}-{{ partial_version }}-complete&os={{ buildbot2bouncer(platform) }}&lang={{ locale }}"
+                        to_mar: "https://queue.taskcluster.net/v1/task/{{ stableSlugId('{}_artifacts_{}'.format(buildername, chunk)) }}/artifacts/public/build/{{ product }}-{{ appVersion }}.{{ locale }}.{{ buildbot2ftp(platform) }}.complete.mar"
+                        platform: {{ platform }}
+                        branch: {{ branch }}
+                        previousVersion: {{ partial_version }}
+                        previousBuildNumber: {{ partial_info["buildNumber"] }}
+                        toVersion: {{ version }}
+                        toBuildNumber: {{ buildNumber }}
 {% endfor %}
-{% endfor %}
+            treeherderEnv:
+                - staging
+            treeherder:
+                symbol: {{ chunk }}-{{ partial_version }}-g
+                groupSymbol: Update
+                collection:
+                    opt: true
+                machine:
+                    platform: {{ get_treeherder_platform(platform) }}
+                build:
+                    platform: {{ get_treeherder_platform(platform) }}
 
-# TODO: include funsize
+        workerType: "funsize-mar-generator"
+        provisionerId: "aws-provisioner-v1"
+
+        tags:
+            createdForUser: release+funsize@mozilla.com
+
+        payload:
+            image: "rail/funsize-update-generator:latest"
+            maxRunTime: 3600
+            command:
+                - /runme.sh
+
+            env:
+                {% if signing_class == "dep-signing" %}
+                MOZ_DISABLE_MAR_CERT_VERIFICATION: true
+                SIGNING_CERT: "dep"
+                {% else %}
+                SIGNING_CERT: "release"
+                {% endif %}
+
+            artifacts:
+                "public/env":
+                    path: /home/worker/artifacts/
+                    type: directory
+                    expires: "{{ never }}"
+
+-
+    taskId: "{{ stableSlugId('{}_{}_{}_signing_task'.format(buildername, chunk, partial_version)) }}"
+    requires:
+        - "{{ stableSlugId('{}_{}_{}_update_generator'.format(buildername, chunk, partial_version)) }}"
+    task:
+        created: "{{ now }}"
+        deadline: "{{ now.replace(hours=24) }}"
+        expires: "{{ never }}"
+        priority: "high"
+        metadata:
+            owner: release+funsize@mozilla.com
+            source: https://github.com/mozilla/funsize
+            name: "[funsize] MAR signing task"
+            description: |
+                This task signs MAR files and publishes signed bits.
+
+        routes:
+            - tc-treeherder-stage.{{ branch }}.{{ revision_hash }}
+            # TOOD: add index routes
+        extra:
+            signing:
+               # assert that this signing task was created by the real releaserunner
+               signature: {{ sign_task(stableSlugId('{}_{}_{}_signing_task'.format(buildername, chunk, partial_version)),
+                                       valid_for=8 * 3600) }}
+            {% if running_tests is defined %}
+            task_name: "{{ '{}_{}_{}_signing_task'.format(buildername, chunk, partial_version) }}"
+            {% endif %}
+
+            treeherderEnv:
+                - staging
+            treeherder:
+                symbol: {{ chunk }}-{{ partial_version }}-s
+                groupSymbol: Update
+                collection:
+                    opt: true
+                machine:
+                    platform: {{ get_treeherder_platform(platform) }}
+                build:
+                    platform: {{ get_treeherder_platform(platform) }}
+
+        workerType: "signing-worker-v1"
+        provisionerId: "signing-provisioner-v1"
+        scopes:
+            - signing:cert:{{ signing_class }}
+            - signing:format:gpg
+            - signing:format:mar
+        tags:
+            createdForUser: release+funsize@mozilla.com
+
+        payload:
+            signingManifest: "https://queue.taskcluster.net/v1/task/{{ stableSlugId('{}_{}_{}_update_generator'.format(buildername, chunk, partial_version)) }}/artifacts/public/env/manifest.json"
+
+-
+    taskId: "{{ stableSlugId('{}_{}_{}_balrog_task'.format(buildername, chunk, partial_version)) }}"
+    requires:
+        - "{{ stableSlugId('{}_{}_{}_signing_task'.format(buildername, chunk, partial_version)) }}"
+    task:
+        created: "{{ now }}"
+        deadline: "{{ now.replace(hours=24) }}"
+        expires: "{{ never }}"
+        priority: "high"
+        routes:
+            - tc-treeherder-stage.{{ branch }}.{{ revision_hash }}
+            # TODO: add index routes
+        extra:
+            {% if running_tests is defined %}
+            task_name: "{{ '{}_{}_{}_balrog_task'.format(buildername, chunk, partial_version) }}"
+            {% endif %}
+
+            treeherderEnv:
+                - staging
+            treeherder:
+                symbol: {{ chunk }}-{{ partial_version }}-u
+                groupSymbol: Update
+                collection:
+                    opt: true
+                machine:
+                    platform: {{ get_treeherder_platform(platform) }}
+                build:
+                    platform: {{ get_treeherder_platform(platform) }}
+
+        metadata:
+            owner: release+funsize@mozilla.com
+            source: https://github.com/mozilla/funsize
+            name: "[funsize] Publish to Balrog"
+            description: |
+                This task publishes signed updates to Balrog.
+
+        workerType: "funsize-balrog"
+        provisionerId: "aws-provisioner-v1"
+        {% if signing_class != "dep-signing" %}
+        scopes:
+            - docker-worker:feature:balrogVPNProxy
+        {% endif %}
+        tags:
+            createdForUser: release+funsize@mozilla.com
+
+        payload:
+            image: "rail/funsize-balrog-submitter:latest"
+            maxRunTime: 1800
+            command:
+                - /runme.sh
+
+            env:
+                {% if signing_class == "dep-signing" %}
+                MOZ_DISABLE_MAR_CERT_VERIFICATION: true
+                SIGNING_CERT: "dep"
+                {% else %}
+                SIGNING_CERT: "release"
+                {% endif %}
+                PARENT_TASK_ARTIFACTS_URL_PREFIX: "https://queue.taskcluster.net/v1/task/{{ stableSlugId('{}_{}_{}_signing_task'.format(buildername, chunk, partial_version)) }}/artifacts/public/env"
+                BALROG_API_ROOT: {{ balrog_api_root }}
+                # TODO: should funsize be publishing to an s3 bucket? or will beetmover do that?
+                {% if extra_balrog_submitter_params is defined %}
+                EXTRA_BALROG_SUBMITTER_PARAMS: "{{ extra_balrog_submitter_params }}"
+                {% endif %}
+            encryptedEnv:
+                - {{ encrypt_env_var(stableSlugId('{}_{}_{}_balrog_task'.format(buildername, chunk, partial_version)), now_ms,
+                                    now_ms + 24 * 3600 * 1000, "BALROG_USERNAME",
+                                    balrog_username) }}
+                - {{ encrypt_env_var(stableSlugId('{}_{}_{}_balrog_task'.format(buildername, chunk, partial_version)), now_ms,
+                                    now_ms + 24 * 3600 * 1000, "BALROG_PASSWORD",
+                                    balrog_password) }}
+            {% if signing_class != "dep-signing" %}
+            features:
+                balrogVPNProxy: true
+            {% endif %}
+{% endfor %} # partials
+{% endfor %} # l10n chunks
+{% endfor %} # platforms

--- a/releasetasks/test/test_releasetasks.py
+++ b/releasetasks/test/test_releasetasks.py
@@ -389,6 +389,16 @@ class TestMakeTaskGraph(unittest.TestCase):
                     "zh-TW": "default",
                 },
             },
+            partial_updates={
+                "38.0": {
+                    "buildNumber": 1,
+                },
+                "37.0": {
+                    "buildNumber": 2,
+                },
+            },
+            balrog_api_root="https://fake.balrog/api",
+            signing_class="release-signing",
             branch="mozilla-beta",
             product="firefox",
             repo_path="releases/mozilla-beta",
@@ -450,6 +460,16 @@ class TestMakeTaskGraph(unittest.TestCase):
                     "zh-TW": "default",
                 },
             },
+            partial_updates={
+                "38.0": {
+                    "buildNumber": 1,
+                },
+                "37.0": {
+                    "buildNumber": 2,
+                },
+            },
+            signing_class="release-signing",
+            balrog_api_root="https://fake.balrog/api",
             branch="mozilla-beta",
             product="firefox",
             repo_path="releases/mozilla-beta",
@@ -479,6 +499,8 @@ class TestMakeTaskGraph(unittest.TestCase):
         self.assertIsNotNone(get_task_by_name(graph, "release-mozilla-beta_firefox_win32_l10n_repack_artifacts_1"))
         self.assertIsNotNone(get_task_by_name(graph, "release-mozilla-beta_firefox_win32_l10n_repack_artifacts_2"))
         self.assertIsNone(get_task_by_name(graph, "release-mozilla-beta_firefox_win32_l10n_repack_artifacts_3"))
+        # partials
+        self.assertIsNotNone(get_task_by_name(graph, "release-mozilla-beta_firefox_win32_l10n_repack_1_37.0_update_generator"))
 
     def test_encryption(self):
         graph = make_task_graph(


### PR DESCRIPTION
Initial set of tasks to generate partials for l10n.
1. Whenever beetmover is ready, we will need to inject it between signing and publishing (so we get better URLs)
2. We may want to chunk the chunks to ||lize generation. 
