### PR TITLE
Update treeherder-client dependency from * to >=2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "requests>=2.4.3,<=2.7.0",
     "PyYAML",
     "chunkify",
-    "treeherder-client",
+    "treeherder-client>=2.0.1",
     "PGPy",
     "buildtools",
     "python-jose",


### PR DESCRIPTION
To ensure deprecated versions of TreeherderClient aren't being used if the virtualenv is reused.

Notably 2.0.1 includes an API URL fix that will prevent 404s once non-canonical URLs are disabled in bug 1234233.
