### PR TITLE
fix platform, repo, and cd to mozharness before calling beetmover

### DIFF
--- a/releasetasks/templates/beetmover_enUS_push_to_candidates.yml.tmpl
+++ b/releasetasks/templates/beetmover_enUS_push_to_candidates.yml.tmpl
@@ -19,9 +19,9 @@
                 - /bin/bash
                 - -c
                 - >
-                  wget -O mozharness.tar.bz2 https://hg.mozilla.org/releases/{{ branch }}/archive/{{ revision }}.tar.bz2/testing/mozharness &&
-                  mkdir mozharness && tar xvfj mozharness.tar.bz2 -C mozharness --strip-components 3 &&
-                  python scripts/release/beet_mover.py --template configs/beetmover/en_us.yml.tmpl --platform {{ platform_info['upload_platform'] }} --version {{ version }} --app-version {{ appVersion }} --locale en-US --taskid {{ platform_info['task_id'] }} --build-num build{{ buildNumber }}
+                  wget -O mozharness.tar.bz2 https://hg.mozilla.org/{{ repo_path }}/archive/{{ revision }}.tar.bz2/testing/mozharness &&
+                  mkdir mozharness && tar xvfj mozharness.tar.bz2 -C mozharness --strip-components 3 && cd mozharness &&
+                  python scripts/release/beet_mover.py --template configs/beetmover/en_us.yml.tmpl --platform {{ buildbot2ftp(platform) }} --version {{ version }} --app-version {{ appVersion }} --locale en-US --taskid {{ platform_info['task_id'] }} --build-num build{{ buildNumber }}
             encryptedEnv:
                 - {{ encrypt_env_var(stableSlugId(buildername), now_ms,
                                    now_ms + 24 * 3600 * 1000, 'AWS_ACCESS_KEY_ID',


### PR DESCRIPTION
this fixes some template variables. Also, looks like we already have buildbot2ftp available to us[1]. So I'll remove that logic in tools' release-runner.py

[1] https://github.com/mozilla/releasetasks/blob/master/releasetasks/__init__.py#L52
