### PR TITLE
Fix buildernames to match BBB names

### DIFF
--- a/releasetasks/templates/version_bump.yml.tmpl
+++ b/releasetasks/templates/version_bump.yml.tmpl
@@ -1,4 +1,4 @@
-{% set buildername = "release-{}_{}_version_bump".format(branch, product) %}
+{% set buildername = "release-{}-{}_version_bump".format(branch, product) %}
 -
     taskId: "{{ stableSlugId('{}_human_decision'.format(buildername)) }}"
     reruns: 5

--- a/releasetasks/test/test_version_bump.py
+++ b/releasetasks/test/test_version_bump.py
@@ -41,9 +41,9 @@ class TestVersionBump(unittest.TestCase):
             signing_pvt_key=PVT_KEY_FILE,
         )
         self.task = get_task_by_name(
-            self.graph, "release-foo_firefox_version_bump")
+            self.graph, "release-foo-firefox_version_bump")
         self.human_task = get_task_by_name(
-            self.graph, "release-foo_firefox_version_bump_human_decision")
+            self.graph, "release-foo-firefox_version_bump_human_decision")
         self.payload = self.task["task"]["payload"]
 
     def test_common_assertions(self):


### PR DESCRIPTION
http://buildbot-master91.bb.releng.usw2.mozilla.com:8001/builders/release-date-firefox_version_bump does exist!
