### PR TITLE
Bug 1247428 - move release promotion Dockerfiles in tree

### DIFF
--- a/releasetasks/templates/enUS.yml.tmpl
+++ b/releasetasks/templates/enUS.yml.tmpl
@@ -16,7 +16,7 @@
         payload:
             maxRunTime: 7200
             # TODO - create specific image for this
-            image: kmoir/python-kmoir-runner
+            image: kmoir/python-beet-runner
             command:
                 - /bin/bash
                 - -c

--- a/releasetasks/templates/enUS.yml.tmpl
+++ b/releasetasks/templates/enUS.yml.tmpl
@@ -16,7 +16,7 @@
         payload:
             maxRunTime: 7200
             # TODO - create specific image for this
-            image: rail/python-test-runner
+            image: kmoir/python-kmoir-runner
             command:
                 - /bin/bash
                 - -c
@@ -297,7 +297,7 @@
         payload:
             maxRunTime: 7200
             # TODO - create specific image for this
-            image: rail/python-test-runner
+            image: kmoir/python-beet-runner
             command:
                 - /bin/bash
                 - -c

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -98,7 +98,7 @@
         payload:
             maxRunTime: 7200
             # TODO - create specific image for this
-            image: rail/python-test-runner
+            image: kmoir/python-beet-runner
             command:
                 - /bin/bash
                 - -c
@@ -369,7 +369,7 @@
         payload:
             maxRunTime: 7200
             # TODO - create specific image for this
-            image: rail/python-test-runner
+            image: kmoir/python-beet-runner
             command:
                 - /bin/bash
                 - -c


### PR DESCRIPTION
update docker image for beetmover tasks to use new docker image with virus scanning tools installed
