### PR TITLE
adds global variables buildernames that generate beetmover artifacts

### DIFF
--- a/releasetasks/__init__.py
+++ b/releasetasks/__init__.py
@@ -21,7 +21,8 @@ def make_task_graph(public_key, signing_pvt_key,
                     **template_kwargs):
     # TODO: some validation of template_kwargs + defaults
     env = Environment(loader=FileSystemLoader(template_dir),
-                      undefined=StrictUndefined)
+                      undefined=StrictUndefined,
+                      extensions=['jinja2.ext.do'])
     th = TreeherderClient()
 
     now = arrow.now()

--- a/releasetasks/templates/enUS.yml.tmpl
+++ b/releasetasks/templates/enUS.yml.tmpl
@@ -2,6 +2,7 @@
 
 {% if push_to_candidates_enabled %}  # beetmover
 {% set complete_beetmover_basename = "release-{}_{}_{}_complete_en-US_beetmover_candidates".format(branch, product, platform) %}
+{% do artifact_completes_builders.append(complete_beetmover_basename) %}
 -
     taskId: "{{ stableSlugId(complete_beetmover_basename) }}"
     reruns: 5
@@ -281,6 +282,7 @@
 
 {% if push_to_candidates_enabled %}  # beetmover partials
 {% set partial_beetmover_basename = "release-{}_{}_{}_partial_en-US_{}build{}_beetmover_candidates".format(branch, product, platform, partial_version, partial_info["buildNumber"]) %}
+{% do artifact_partials_builders.append(partial_beetmover_basename) %}
 -
     taskId: "{{ stableSlugId(partial_beetmover_basename) }}"
     requires:
@@ -342,6 +344,5 @@
 
 {% endfor %} # partials
 {% endif %}  # updates_enabled
-
 
 {% endfor %} # platforms

--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -82,6 +82,7 @@
 
 # repacks beetmover
 {% if push_to_candidates_enabled %}
+{% do artifact_completes_builders.append('{}_beetmover_candidates_{}'.format(buildername, chunk)) %}
 -
     taskId: "{{ stableSlugId('{}_beetmover_candidates_{}'.format(buildername, chunk)) }}"
     requires:
@@ -353,6 +354,7 @@
 # repacks beetmover
 {% if push_to_candidates_enabled %}
 {% set partial_beetmover_buildername = "{}_partial_{}build{}_beetmover_candidates_{}".format(buildername, partial_version, partial_info["buildNumber"], chunk) %}
+{% do artifact_partials_builders.append(partial_beetmover_buildername) %}
 -
     taskId: "{{ stableSlugId(partial_beetmover_buildername) }}"
     requires:

--- a/releasetasks/templates/release_graph.yml.tmpl
+++ b/releasetasks/templates/release_graph.yml.tmpl
@@ -1,3 +1,7 @@
+# store all en-US artifact generating tasks for upstream builder purposes
+{% set artifact_completes_builders = [] %}
+{% set artifact_partials_builders = [] %}
+
 ---
 metadata:
     name: "Release Promotion"
@@ -98,3 +102,4 @@ tasks:
         {% endmacro %}
         {{ version_bump_tasks()|indent(4) }}
     {% endif %}
+


### PR DESCRIPTION
so we can do things like:

```
- requires:
        {% for upstream_builder in artifact_completes_builders + artifact_partials_builders %}
        - {{ stableSlugId(upstream_builder) }}
        {% endfor %}
```

@rail ?
