### PR TITLE
Bug 1253871 - L10N repacks should use martools from en-US build, not

### DIFF
--- a/releasetasks/templates/l10n.yml.tmpl
+++ b/releasetasks/templates/l10n.yml.tmpl
@@ -30,6 +30,7 @@
             properties:
                 product: "{{ product }}"
                 en_us_binary_url: "{{ platform_info['en_us_binary_url'] }}"
+                mar_tools_url: "{{ platform_info['en_us_binary_url'] }}"
                 # Quotes cannot be used around this string because the loop causes it to have trailing whitespace
                 # (which gets stripped by the yaml parser when unquoted). Kindof hacky.
                 locales: {% for l in our_locales %}{{ "{}:{} ".format(l, l10n_config["changesets"][l]) }}{% endfor %}


### PR DESCRIPTION
from latest dir
