### PR TITLE
Bug 1259423 - freshclam fails to update the DB

### DIFF
--- a/releasetasks/templates/firefox/enUS.yml.tmpl
+++ b/releasetasks/templates/firefox/enUS.yml.tmpl
@@ -142,7 +142,7 @@
             createdForUser: release+funsize@mozilla.com
 
         payload:
-            image: "rail/funsize-update-generator@sha256:ce45316c7a7dede6fc74f0fc7259a34d1616c2e207dbd036225454bbbb8e3d32"
+            image: "rail/funsize-update-generator@sha256:d1c88af7f13d124e08a37d10203e9e60655a231301123e5f2127fab5468ef5dd"
             maxRunTime: 3600
             command:
                 - /runme.sh

--- a/releasetasks/templates/firefox/l10n.yml.tmpl
+++ b/releasetasks/templates/firefox/l10n.yml.tmpl
@@ -225,7 +225,7 @@
             createdForUser: release+funsize@mozilla.com
 
         payload:
-            image: "rail/funsize-update-generator@sha256:ce45316c7a7dede6fc74f0fc7259a34d1616c2e207dbd036225454bbbb8e3d32"
+            image: "rail/funsize-update-generator@sha256:d1c88af7f13d124e08a37d10203e9e60655a231301123e5f2127fab5468ef5dd"
             maxRunTime: 7200
             command:
                 - /runme.sh


### PR DESCRIPTION
new image for funsize-update-generator
