### PR TITLE
include channel name in final verify task

### DIFF
--- a/releasetasks/templates/firefox/final_verify.yml.tmpl
+++ b/releasetasks/templates/firefox/final_verify.yml.tmpl
@@ -46,7 +46,7 @@
         metadata:
             owner: release@mozilla.com
             source: https://github.com/mozilla/releasetasks
-            name: "{{ branch }} final verification"
+            name: "{{ branch }} {{ channel }} final verification"
             description: |
                 Verifies that all release blobs are in the correct place
 


### PR DESCRIPTION
this way it is clear for RC releases when we are doing a "mozilla-release beta final verify" or "mozilla-release release final verify"

@rail  r?
