### PR TITLE
Bug 1278312 - fix uptake for graph2. r=rail

### DIFF
--- a/releasetasks/release_configs/dev_mozilla-release_firefox_rc_graph_2.yml
+++ b/releasetasks/release_configs/dev_mozilla-release_firefox_rc_graph_2.yml
@@ -7,6 +7,12 @@ final_verify_platforms:
   - "win32"
   - "win64"
   - "macosx64"
+uptake_monitoring_platforms:
+  - "linux"
+  - "linux64"
+  - "win32"
+  - "win64"
+  - "macosx64"
 l10n_release_platforms: []
 partner_repacks_platforms: []
 

--- a/releasetasks/release_configs/prod_mozilla-esr45_firefox_rc_graph_2.yml
+++ b/releasetasks/release_configs/prod_mozilla-esr45_firefox_rc_graph_2.yml
@@ -7,6 +7,12 @@ final_verify_platforms:
   - "win32"
   - "win64"
   - "macosx64"
+uptake_monitoring_platforms:
+  - "linux"
+  - "linux64"
+  - "win32"
+  - "win64"
+  - "macosx64"
 l10n_release_platforms: []
 partner_repacks_platforms: []
 

--- a/releasetasks/release_configs/prod_mozilla-release_firefox_rc_graph_2.yml
+++ b/releasetasks/release_configs/prod_mozilla-release_firefox_rc_graph_2.yml
@@ -7,6 +7,12 @@ final_verify_platforms:
   - "win32"
   - "win64"
   - "macosx64"
+uptake_monitoring_platforms:
+  - "linux"
+  - "linux64"
+  - "win32"
+  - "win64"
+  - "macosx64"
 l10n_release_platforms: []
 partner_repacks_platforms: []
 

--- a/releasetasks/templates/firefox/common_extras.yml.tmpl
+++ b/releasetasks/templates/firefox/common_extras.yml.tmpl
@@ -13,6 +13,7 @@ build_props:
     version: "{{ version }}"
     revision: {{ revision }}
     build_number: {{ buildNumber }}
+    partials: {% set pipe = joiner(", ") %}{% for p, e in sorted(partial_updates.items()) %}{{ pipe() }}{{ "{}build{}".format(p, e["buildNumber"]) }}{% endfor %}
 
 signing:
    signature: {{ sign_task(stableSlugId(taskname), valid_for=4 * 24 * 3600) }}

--- a/releasetasks/templates/firefox/uptake_monitoring.yml.tmpl
+++ b/releasetasks/templates/firefox/uptake_monitoring.yml.tmpl
@@ -35,7 +35,7 @@
                 revision: "{{ revision }}"
                 tuxedo_server_url: "{{ tuxedo_server_url }}"
                 partial_versions: {% set pipe = joiner(", ") %}{% for p, e in sorted(partial_updates.items()) %}{{ pipe() }}{{ "{}build{}".format(p, e["buildNumber"]) }}{% endfor %}
-                platforms: {{ en_US_config["platforms"] | sort() | join(", ") }}
+                platforms: "{{ uptake_monitoring_platforms }}"
         metadata:
             name: "{{ product }} {{ branch }} uptake monitoring"
             description: "Release Promotion uptake monitoring"

--- a/releasetasks/test/firefox/test_final_verification.py
+++ b/releasetasks/test/firefox/test_final_verification.py
@@ -59,6 +59,7 @@ class TestFinalVerification(unittest.TestCase):
             release_channels=["foo"],
             final_verify_channels=["foo"],
             final_verify_platforms=["macosx64", "win32", "win64", "linux", "linux64"],
+            uptake_monitoring_platforms=["macosx64", "win32", "win64", "linux", "linux64"],
             balrog_api_root="https://balrog.real/api",
             funsize_balrog_api_root="http://balrog/api",
             enUS_platforms=["linux", "linux64", "win64", "win32", "macosx64"],

--- a/releasetasks/test/firefox/test_full_featured_graph.py
+++ b/releasetasks/test/firefox/test_full_featured_graph.py
@@ -50,6 +50,7 @@ class TestFullGraph(unittest.TestCase):
             postrelease_version_bump_enabled=True,
             postrelease_bouncer_aliases_enabled=True,
             tuxedo_server_url="https://bouncer.real.allizom.org/api",
+            uptake_monitoring_platforms=["macosx64", "win32", "win64", "linux", "linux64"],
             signing_class="release-signing",
             verifyConfigs={},
             release_channels=["foo"],

--- a/releasetasks/test/firefox/test_source.py
+++ b/releasetasks/test/firefox/test_source.py
@@ -25,6 +25,16 @@ class TestSourceBuilder(unittest.TestCase):
                 "linux": {"task_id": "xyz"},
                 "win32": {"task_id": "xyy"}
             }},
+            partial_updates={
+                "38.0": {
+                    "buildNumber": 1,
+                    "locales": ["de", "en-GB", "zh-TW"],
+                },
+                "37.0": {
+                    "buildNumber": 2,
+                    "locales": ["de", "en-GB", "zh-TW"],
+                },
+            },
             l10n_config={},
             repo_path="releases/foo",
             revision="fedcba654321",

--- a/releasetasks/test/firefox/test_uptake_monitoring.py
+++ b/releasetasks/test/firefox/test_uptake_monitoring.py
@@ -55,6 +55,7 @@ class TestUptakeMonitoring(unittest.TestCase):
             postrelease_version_bump_enabled=False,
             postrelease_bouncer_aliases_enabled=False,
             tuxedo_server_url="https://bouncer.real.allizom.org/api",
+            uptake_monitoring_platforms=["macosx64", "win32", "win64", "linux", "linux64"],
             signing_class="release-signing",
             release_channels=["foo"],
             final_verify_channels=["foo"],


### PR DESCRIPTION
Fix the "partial_versions" and "platforms" fields for release promotion graph2.
