### PR TITLE
Revert "Use temp image to generate sources" because source generation…

### DIFF
--- a/releasetasks/templates/firefox/source.yml.tmpl
+++ b/releasetasks/templates/firefox/source.yml.tmpl
@@ -28,7 +28,7 @@
 
         payload:
             maxRunTime: 7200
-            image: rail/source-builder@sha256:20ea2d9aff06740d6a35ff2f42af98c8d8b65efec9d0dea48692fbb3025d5d8c
+            image: taskcluster/desktop-build:0.1.11
             cache:
                 build-{{ branch }}-release-workspace: /home/worker/workspace
                 tooltool-cache: /home/worker/tooltool-cache

--- a/releasetasks/test/firefox/test_source.py
+++ b/releasetasks/test/firefox/test_source.py
@@ -43,7 +43,7 @@ class TestSourceBuilder(unittest.TestCase):
         assert self.task["workerType"] == "opt-linux64"
 
     def test_image_name(self):
-        assert self.payload["image"].startswith("rail/source-builder@sha256")
+        assert self.payload["image"].startswith("taskcluster/desktop-build:")
 
     def test_cache_in_payload(self):
         assert "cache" in self.payload


### PR DESCRIPTION
… is busted in 49.0.1 build1

This reverts commit 2be9dc596566f06fed1817b72e8c22b6ec6ba9f7.
