### PR TITLE
use mozilla-unified as the base repo for image tasks

### DIFF
--- a/releasetasks/templates/fennec/beetmove_image.yml.tmpl
+++ b/releasetasks/templates/fennec/beetmove_image.yml.tmpl
@@ -32,7 +32,7 @@
                 HG_STORE_PATH: /home/worker/checkouts/hg-store
                 CONTEXT_URL: ""
                 GECKO_HEAD_REV: "{{ revision }}"
-                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
+                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/mozilla-unified"
                 GECKO_HEAD_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
         metadata:
             name: "Generate beetmover docker image"

--- a/releasetasks/templates/firefox/beetmove_image.yml.tmpl
+++ b/releasetasks/templates/firefox/beetmove_image.yml.tmpl
@@ -32,7 +32,7 @@
                 HG_STORE_PATH: /home/worker/checkouts/hg-store
                 CONTEXT_URL: ""
                 GECKO_HEAD_REV: "{{ revision }}"
-                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
+                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/mozilla-unified"
                 GECKO_HEAD_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
         metadata:
             name: "Generate beetmover docker image"

--- a/releasetasks/templates/firefox/funsize_image.yml.tmpl
+++ b/releasetasks/templates/firefox/funsize_image.yml.tmpl
@@ -32,7 +32,7 @@
                 HG_STORE_PATH: /home/worker/checkouts/hg-store
                 CONTEXT_URL: ""
                 GECKO_HEAD_REV: "{{ revision }}"
-                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
+                GECKO_BASE_REPOSITORY: "https://hg.mozilla.org/mozilla-unified"
                 GECKO_HEAD_REPOSITORY: "https://hg.mozilla.org/{{ repo_path }}"
         metadata:
             name: "Generate funsize-update-generator docker image"


### PR DESCRIPTION
We keep timing out on hg clone for docker image generation. Let's use mozilla-unified as the base repo.