### PR TITLE
Updates for bug 1351318, allow macs to use native platform

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Testing
 -------
 
 Example test invocation using docker:
-  docker run --rm -v `pwd`:/src -ti rail/python-test-runner /bin/sh -c "cd /src && tox"
+  docker run --rm -v $(pwd):/src -ti rail/python-test-runner /bin/sh -c "cd /src && tox"
 
 Or to run a single test:
-  docker run --rm -v `pwd`:/src -ti rail/python-test-runner /bin/sh -c "cd /src && .tox/py27/bin/py.test --verbose --doctest-modules releasetasks/test/firefox/test_updates.py::TestUpdates::test_requires"
+  docker run --rm -v $(pwd):/src -ti rail/python-test-runner /bin/sh -c "cd /src && .tox/py27/bin/py.test --verbose --doctest-modules releasetasks/test/firefox/test_updates.py::TestUpdates::test_requires"

--- a/releasetasks/__init__.py
+++ b/releasetasks/__init__.py
@@ -10,7 +10,7 @@ from taskcluster.utils import stableSlugId, encryptEnvVar
 
 from releasetasks.util import (
     treeherder_platform, sign_task, buildbot2ftp, buildbot2bouncer,
-    get_json_rev)
+    get_json_rev, get_worker_type, get_provisionerid)
 
 DEFAULT_TEMPLATE_DIR = path.join(path.dirname(__file__), "templates")
 
@@ -52,6 +52,8 @@ def make_task_graph(public_key, signing_pvt_key, product, root_home_dir,
         "buildbot2ftp": buildbot2ftp,
         "buildbot2bouncer": buildbot2bouncer,
         "sign_task": partial(sign_task, pvt_key=pvt_key),
+        "workertype": get_worker_type,
+        "provisionerid": get_provisionerid,
     }
     template_vars.update(template_kwargs)
 

--- a/releasetasks/templates/desktop/enUS.yml.tmpl
+++ b/releasetasks/templates/desktop/enUS.yml.tmpl
@@ -9,8 +9,8 @@
         - "{{ stableSlugId("beetmove_image") }}"
     reruns: 5
     task:
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-3-b-linux
+        provisionerId: {{ provisionerid(platform) }}
+        workerType: {{ workertype(platform) }}
         created: "{{ now }}"
         deadline: "{{ now.replace(days=4) }}"
         expires: "{{ never }}"
@@ -316,8 +316,8 @@
         - "{{ stableSlugId("beetmove_image") }}"
     reruns: 5
     task:
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-3-b-linux
+        provisionerId: {{ provisionerid(platform) }}
+        workerType: {{ workertype(platform) }}
         created: "{{ now }}"
         deadline: "{{ now.replace(days=4) }}"
         expires: "{{ never }}"

--- a/releasetasks/templates/desktop/l10n.yml.tmpl
+++ b/releasetasks/templates/desktop/l10n.yml.tmpl
@@ -92,8 +92,8 @@
         - "{{ stableSlugId("beetmove_image") }}"
     reruns: 5
     task:
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-3-b-linux
+        provisionerId: {{ provisionerid(platform) }}
+        workerType: {{ workertype(platform) }}
         created: "{{ now }}"
         deadline: "{{ now.replace(days=4) }}"
         expires: "{{ never }}"
@@ -396,8 +396,8 @@
         - "{{ stableSlugId("beetmove_image") }}"
     reruns: 5
     task:
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-3-b-linux
+        provisionerId: {{ provisionerid(platform) }}
+        workerType: {{ workertype(platform) }}
         created: "{{ now }}"
         deadline: "{{ now.replace(days=4) }}"
         expires: "{{ never }}"

--- a/releasetasks/templates/desktop/tc_update_verify.yml.tmpl
+++ b/releasetasks/templates/desktop/tc_update_verify.yml.tmpl
@@ -15,8 +15,8 @@
         {% endif %}
     reruns: 5
     task:
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-3-b-linux
+        provisionerId: {{ provisionerid(platform) }}
+        workerType: {{ workertype(platform) }}
         created: "{{ now }}"
         deadline: "{{ now.replace(days=4) }}"
         expires: "{{ never }}"

--- a/releasetasks/test/desktop/test_beetmover_candidates.py
+++ b/releasetasks/test/desktop/test_beetmover_candidates.py
@@ -4,7 +4,7 @@ from releasetasks.test.desktop import make_task_graph, do_common_assertions, \
     get_task_by_name, create_firefox_test_args
 from releasetasks.test import generate_scope_validator, PVT_KEY_FILE, verify
 from releasetasks.util import buildbot2ftp
-from voluptuous import Schema, truth
+from voluptuous import Schema, truth, Required, Any
 
 
 EN_US_CONFIG = {
@@ -43,8 +43,8 @@ class TestBeetmoverEnUSCandidates(unittest.TestCase, BaseTestBeetmoverCandidates
     def setUp(self):
         self.task_schema = Schema({
             'task': {
-                'provisionerId': 'aws-provisioner-v1',
-                'workerType': 'gecko-3-b-linux',
+                'provisionerId': Required(Any(str, ['aws-provisioner-v1', 'scl3-puppet'])),
+                'workerType': Required(Any(str, ['gecko-3-b-linux', 'os-x-10-10-gw'])),
                 'extra': {
                     'build_props': {
                         'product': 'firefox',
@@ -140,8 +140,8 @@ class TestBeetmover110nCandidates(unittest.TestCase, BaseTestBeetmoverCandidates
     def setUp(self):
         self.task_schema = Schema({
             'task': {
-                'provisionerId': 'aws-provisioner-v1',
-                'workerType': 'gecko-3-b-linux',
+                'provisionerId': Required(Any(str, ['aws-provisioner-v1', 'scl3-puppet'])),
+                'workerType': Required(Any(str, ['gecko-3-b-linux', 'os-x-10-10-gw'])),
                 'extra': {
                     'build_props': {
                         'product': 'firefox',
@@ -226,8 +226,8 @@ class TestBeetmoverEnUSPartialsCandidates(unittest.TestCase, BaseTestBeetmoverCa
     def setUp(self):
         self.task_schema = Schema({
             'task': {
-                'provisionerId': 'aws-provisioner-v1',
-                'workerType': 'gecko-3-b-linux',
+                'provisionerId': Required(Any(str, ['aws-provisioner-v1', 'scl3-puppet'])),
+                'workerType': Required(Any(str, ['gecko-3-b-linux', 'os-x-10-10-gw'])),
             }
         }, extra=True, required=True)
 
@@ -332,8 +332,8 @@ class TestBeetmoverl10nPartialsCandidates(unittest.TestCase, BaseTestBeetmoverCa
     def setUp(self):
         self.task_schema = Schema({
             'task': {
-                'provisionerId': 'aws-provisioner-v1',
-                'workerType': 'gecko-3-b-linux',
+                'provisionerId': Required(Any(str, ['aws-provisioner-v1', 'scl3-puppet'])),
+                'workerType': Required(Any(str, ['gecko-3-b-linux', 'os-x-10-10-gw'])),
             }
         }, extra=True, required=True)
 

--- a/releasetasks/util.py
+++ b/releasetasks/util.py
@@ -21,6 +21,25 @@ bouncer_platform_map = {
     'macosx64': 'osx'
 }
 
+workertype_map = {
+    'win32': 'gecko-3-b-linux',
+    'win64': 'gecko-3-b-linux',
+    'linux': 'gecko-3-b-linux',
+    'linux64': 'gecko-3-b-linux',
+    'macosx64': 'os-x-10-10-gw'
+}
+
+provisionerid_map = {
+    'win32': 'aws-provisioner-v1',
+    'win64': 'aws-provisioner-v1',
+    'linux': 'aws-provisioner-v1',
+    'linux64': 'aws-provisioner-v1',
+    'macosx64': 'scl3-puppet'
+}
+
+DEFAULT_WORKER_TYPE = 'gecko-3-b-linux'
+DEFAULT_PROVISIONER_ID = 'aws-provisioner-v1'
+
 
 def treeherder_platform(platform):
     # See https://github.com/mozilla/treeherder/blob/master/ui/js/values.js
@@ -57,6 +76,14 @@ def buildbot2ftp(platform):
 
 def buildbot2bouncer(platform):
     return bouncer_platform_map.get(platform, platform)
+
+
+def get_worker_type(platform):
+    return workertype_map.get(platform, DEFAULT_WORKER_TYPE)
+
+
+def get_provisionerid(platform):
+    return provisionerid_map.get(platform, DEFAULT_PROVISIONER_ID)
 
 
 @retriable(sleeptime=0, jitter=0, retry_exceptions=(requests.HTTPError,))


### PR DESCRIPTION
I think all the places where the build platform needs to be native have been modified, best to double check those.

I can see how it's meant to be run using https://github.com/mozilla/releasewarrior/blob/master/how-tos/fennec-temp-relpro.md#start-off-the-fennec-graph but it's not clear what all the TODO entries are meant to actually be, so while it passes the tests I don't know if the resultant graph matches expectations.