### PR TITLE
Bug 1389420 - [mozilla-release leftovers] Rename android-api-15 to an…

### DIFF
--- a/releasetasks/release_configs/dev_mozilla-release_fennec_full_graph.yml
+++ b/releasetasks/release_configs/dev_mozilla-release_fennec_full_graph.yml
@@ -3,7 +3,7 @@ platforms: {}
 release_platforms: []
 final_verify_platforms: []
 uptake_monitoring_platforms:
-  - "android-api-15"
+  - "android-api-16"
   - "android-x86"
 l10n_release_platforms: []
 partner_repacks_platforms: []

--- a/releasetasks/release_configs/prod_mozilla-release_fennec_full_graph.yml
+++ b/releasetasks/release_configs/prod_mozilla-release_fennec_full_graph.yml
@@ -3,7 +3,7 @@ platforms: {}
 release_platforms: []
 final_verify_platforms: []
 uptake_monitoring_platforms:
-  - "android-api-15"
+  - "android-api-16"
   - "android-x86"
 l10n_release_platforms: []
 partner_repacks_platforms: []


### PR DESCRIPTION
…droid-api-16 once 56 reaches release